### PR TITLE
fix #21 Add issue and pull-request template

### DIFF
--- a/docs/ISSUE_TEMPLATE/Bug_report.md
+++ b/docs/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,18 @@
+# Describe the bug
+A clear and concise description of what the bug is.
+
+# Stacktrace Copy
+all of the output of the command, including the stacktrace if visible.
+
+# To Reproduce
+Steps to reproduce the behavior. 
+Include the full command being run as well as, if possible, artifacts the bug can be reproduced with.
+
+# Expected behavior
+A clear and concise description of what you expected to happen.
+
+# Known workaround
+If you have found a workaround, please specify what it is.
+
+# Additional context
+Add any other context about the problem here.

--- a/docs/ISSUE_TEMPLATE/Feature_request.md
+++ b/docs/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,11 @@
+# Is your feature request related to a problem? Please describe.
+A clear and concise description of what the problem is. Ex. It's very inconvenient to have to do [...]
+
+# Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+# Describe alternatives you've considered
+A clear and concise description of any alternative solutions or features you've considered.
+
+# Additional context
+Add any other context or screenshots about the feature request here.

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,11 @@
+# Changes proposed in this pull request
+* For issue #xxx
+
+# What did you Implement: 
+* xxx
+
+# How Has This Been Tested? 
+* xxx
+
+# Reference
+> https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/


### PR DESCRIPTION
* pull-request template refs is below.
  * https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository

> To store your file in a hidden directory, type .github/, then the name of your pull request template. For example, .github/pull_request_template.md. 

I'm confused, but make it docs instead of .github.