### PR TITLE
✨Add restart command✨

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,111 @@ Tools that shutdown GCP Instance on your schedule.
 
 * Shutdown target
    * GCE, GKE, SQL
-   * The label `state-scheduler: true` is required to stop / resume the instance.
+   * The label `state-scheduler: true` is required to stop / restart the instance.
    * In order to be processed, it is necessary to assign a label to Instance, InstanceGroup or Cluster.
    If a label is assigned to Cluster or InstanceGroup, this tool will reduce the size of InstanceGroup to 0.   
 * Architecture
   * Cloud Scheduler --> Pub/Sub --> CloudFunction
     * https://cloud.google.com/scheduler/docs/start-and-stop-compute-engine-instances-on-a-schedule
-* 🚧Limitation🚧
-   * Stop only. This tool does not support restart yet
-     * If you need to recover, you should restart instances manually
-
 
 ## Config
 
 * nothing special
   * [GCP_PROJECT is automation set by CloudFunction](https://cloud.google.com/functions/docs/concepts/go-runtime#contextcontext)
 
+## QuickStart
 
-## Getting Started
+Shutdown instances with CLI command.
+
+### Install
+
+```bash
+go get -u github.com/future-architect/gcp-instance-scheduler/cmd/scheduler
+```
+
+### Usage
+
+Need to set `GOOGLE_APPLICATION_CREDENTIALS` in environment variables before cli execution.
+[See setup](https://cloud.google.com/docs/authentication/getting-started)
+
+And then you set label to gcp resource
+```bash
+gcloud compute instances create <insntance-name> --zone us-central1-a
+gcloud compute instances update <insntance-name> --project <project-id> --update-labels state-scheduler=true
+```
+Then you can do below commands.
+
+```bash
+# stop
+$ scheduler stop --project <your gcp project>
+
+# restart
+$ scheduler restart --project <your gcp project>
+```
+
+
+#### Options
+
+You can designate project id and timeout length by using flags.
+If you use slack notification, you have to enable slack notification by adding the flag `--slackNotification`.
+
+```
+>scheduler --help
+gcp-instance-scheduler local execution entry point
+
+Usage:
+  scheduler [command]
+
+Available Commands:
+  help        Help about any command
+  restart     restart is launch shutdown gcp resource
+  stop        stop is execution command that shutdown all gcp resources that assigned target label
+
+Flags:
+      --config string   config file (default is $HOME/.scheduler.yaml)
+  -h, --help            help for scheduler
+
+Use "scheduler [command] --help" for more information about a command.
+``` 
+
+Following variables are used when you did not designate these flags.
+
+|#  |flags                  |variables       |
+|---|-----------------------|----------------|
+| 1 |project(p)             |GCP_PROJECT     |
+| 2 |slackAPIToken          |SLACK_API_TOKEN |
+| 3 |slackChannel           |SLACK_CHANNEL   |
+
+
+## Example: create target resources
+
+Set label for target instance
+
+```sh
+# GCE
+gcloud compute instances update <insntance-name> \
+  --project <project-id> \
+  --update-labels state-scheduler=true
+
+# Instance Group
+gcloud compute instance-templates create <tmeplate-name> ... \
+  --project <project-id> \
+  --labels state-scheduler=true
+
+# Cloud SQL (master must be running)
+gcloud beta sql instances patch <insntance-name> \
+  --project <project-id> \
+  --update-labels state-scheduler=true
+
+# GKE
+gcloud container clusters update <cluster-name> \
+  --project <project-id> \
+  --zone <cluster-master-node-zone> \
+  --update-labels state-scheduler=true
+```
+
+
+## Deploy to GCP CloudFunction
 
 * install [gcloud](https://cloud.google.com/sdk/gcloud/)
 
@@ -58,72 +145,6 @@ gcloud beta scheduler jobs create pubsub shutdown-workday \
   --description 'automatically stop instances'
 ```
 
-## Example: create target resources
-
-Set label for target instance
-
-```sh
-# GCE
-gcloud compute instances update <insntance-name> \
-  --project <project-id> \
-  --update-labels state-scheduler=true
-
-# Instance Group
-gcloud compute instance-templates create <tmeplate-name> ... \
-  --project <project-id> \
-  --labels state-scheduler=true
-
-# Cloud SQL (master must be running)
-gcloud beta sql instances patch <insntance-name> \
-  --project <project-id> \
-  --update-labels state-scheduler=true
-
-# GKE
-gcloud container clusters update <cluster-name> \
-  --project <project-id> \
-  --zone <cluster-master-node-zone> \
-  --update-labels state-scheduler=true
-```
-
-## Local Execution Tool
-
-scheduler
-====
-
-Shutdown instances with executing functions from your console.
-
-### Install
-
-`go get -v github.com/future-architect/gcp-instance-scheduler/cmd/scheduler`
-
-### Usage
-
-You can designate project id and timeout length by using flags.
-If you use slack notification, you have to enable slack notification by adding the flag `--slackNotification`.
-
-```
-scheduler local execution entroy porint
-
-Usage:
-  scheduler [flags]
-
-Flags:
-      --config string         config file (default is $HOME/.gscheduler.yaml)
-  -h, --help                  help for gscheduler
-  -p, --project string        project id (defautl $GCP_PROJECT)
-      --slackChannel string   Slack Channel name (should enable slack notify)
-  -s, --slackNotifyEnable     Enable slack notification
-      --slackToken string     SlackAPI token (should enable slack notify)
-      --timeout string        set timeout seconds (default "60")
-  -t, --toggle                Help message for toggle
-``` 
-Following variables are used when you did not designate these flags.
-
-|#  |flags                  |variables       |
-|---|-----------------------|----------------|
-| 1 |project(p)             |GCP_PROJECT     |
-| 2 |slackAPIToken          |SLACK_API_TOKEN |
-| 3 |slackChannel           |SLACK_CHANNEL   |
 
 ## Tips: Debug Function
 

--- a/cmd/scheduler/cmd/restart.go
+++ b/cmd/scheduler/cmd/restart.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"github.com/future-architect/gcp-instance-scheduler/scheduler"
+	"github.com/spf13/cobra"
+	"os"
+	"time"
+)
+
+var restartCmd = &cobra.Command{
+	Use:   "restart",
+	Short: "restart is launch shutdown gcp resource",
+	Long:  `restart is launch shutdown gcp resource.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectID, slackToken, slackChannel, timeout, slackEnable, err := getFlags(cmd)
+		if err != nil {
+			return err
+		}
+
+		if projectID == "" {
+			return errors.New("not found project variable")
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+		defer cancel()
+
+		return scheduler.Restart(ctx, scheduler.NewOptions(projectID, slackToken, slackChannel, slackEnable))
+	},
+}
+
+func init() {
+	restartCmd.PersistentFlags().StringP("project", "p", os.Getenv("GCP_PROJECT"), "project id (default $GCP_PROJECT)")
+	restartCmd.PersistentFlags().Int("timeout", 60, "set timeout seconds")
+	restartCmd.PersistentFlags().String("slackToken", os.Getenv("SLACK_API_TOKEN"), "SlackAPI token (should enable slack notify)")
+	restartCmd.PersistentFlags().String("slackChannel", os.Getenv("SLACK_CHANNEL"), "Slack Channel name (should enable slack notify)")
+	restartCmd.PersistentFlags().BoolP("slackNotifyEnable", "s", false, "Enable slack notification")
+
+	rootCmd.AddCommand(restartCmd)
+}

--- a/cmd/scheduler/cmd/restart.go
+++ b/cmd/scheduler/cmd/restart.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/future-architect/gcp-instance-scheduler/scheduler"
 	"github.com/spf13/cobra"
+	"log"
 	"os"
 	"time"
 )
@@ -19,6 +20,7 @@ var restartCmd = &cobra.Command{
 			return err
 		}
 
+		log.Printf("Project ID: %v", projectID)
 		if projectID == "" {
 			return errors.New("not found project variable")
 		}

--- a/cmd/scheduler/cmd/stop.go
+++ b/cmd/scheduler/cmd/stop.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"github.com/future-architect/gcp-instance-scheduler/scheduler"
+	"github.com/spf13/cobra"
+	"os"
+	"time"
+)
+
+var stopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "stop is execution command that shutdown all gcp resources that assigned target label",
+	Long:  `stop is execution command that shutdown gcp resources that assigned target label.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projectID, slackToken, slackChannel, timeout, slackEnable, err := getFlags(cmd)
+		if err != nil {
+			return err
+		}
+
+		if projectID == "" {
+			return errors.New("not found project variable")
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+		defer cancel()
+
+		return scheduler.Shutdown(ctx, scheduler.NewOptions(projectID, slackToken, slackChannel, slackEnable))
+	},
+}
+
+func init() {
+	stopCmd.PersistentFlags().StringP("project", "p", os.Getenv("GCP_PROJECT"), "project id (default $GCP_PROJECT)")
+	stopCmd.PersistentFlags().Int("timeout", 60, "set timeout seconds")
+	stopCmd.PersistentFlags().String("slackToken", os.Getenv("SLACK_API_TOKEN"), "SlackAPI token (should enable slack notify)")
+	stopCmd.PersistentFlags().String("slackChannel", os.Getenv("SLACK_CHANNEL"), "Slack Channel name (should enable slack notify)")
+	stopCmd.PersistentFlags().BoolP("slackNotifyEnable", "s", false, "Enable slack notification")
+
+	rootCmd.AddCommand(stopCmd)
+}

--- a/cmd/scheduler/cmd/stop.go
+++ b/cmd/scheduler/cmd/stop.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/future-architect/gcp-instance-scheduler/scheduler"
 	"github.com/spf13/cobra"
+	"log"
 	"os"
 	"time"
 )
@@ -19,6 +20,7 @@ var stopCmd = &cobra.Command{
 			return err
 		}
 
+		log.Printf("Project ID: %v", projectID)
 		if projectID == "" {
 			return errors.New("not found project variable")
 		}

--- a/model/model.go
+++ b/model/model.go
@@ -37,17 +37,15 @@ type Report struct {
 }
 
 func (r *Report) Show() {
-	log.Println("<<<<< " + r.InstanceType + " >>>>>")
+	log.Println("[" + r.InstanceType + "]")
 
-	log.Println("!REPORT!")
-	log.Println("[Shutdown Resource]")
-
-	for i, resource := range r.DoneResources {
-		log.Printf(">> Resouce(%v): %v\n", i+1, resource)
+	log.Printf("└- Shutdown Resource: %v", len(r.DoneResources))
+	for _, resource := range r.DoneResources {
+		log.Printf("  └-- %v\n", resource)
 	}
 
-	log.Println("[Already Shutdown Resource]")
-	for i, resource := range r.AlreadyShutdownResources {
-		log.Printf(">> Resouce(%v): %v\n", i+1, resource)
+	log.Printf("└- Already Shutdown Resource: %v", len(r.AlreadyShutdownResources))
+	for _, resource := range r.AlreadyShutdownResources {
+		log.Printf("    └-- %v\n", resource)
 	}
 }

--- a/operator/gke.go
+++ b/operator/gke.go
@@ -82,6 +82,7 @@ func SetLabelNodePoolSize(ctx context.Context, projectID string, targetLabel str
 	return nil
 }
 
+// GetOriginalNodePoolSize returns map that key=instanceGroupName and value=originalSize
 func GetOriginalNodePoolSize(ctx context.Context, projectID string, targetLabel string) (map[string]int64, error) {
 	s, err := container.NewService(ctx)
 	if err != nil {
@@ -103,7 +104,14 @@ func GetOriginalNodePoolSize(ctx context.Context, projectID string, targetLabel 
 			if err != nil {
 				return nil, errors.New("label: " + "restore-size-" + nodePool.Name + " value is not number format?")
 			}
-			result[nodePool.Name] = int64(size)
+
+			for _, url := range nodePool.InstanceGroupUrls {
+				// u;rl is below format
+				// e.g. https://www.googleapis.com/compute/v1/projects/{ProjectID}/zones/us-central1-a/instanceGroupManagers/gke-standard-cluster-1-default-pool-1234abcd-grp
+				urlSplit := strings.Split(url, "/")
+				instanceGroupName := urlSplit[len(urlSplit)-1]
+				result[instanceGroupName] = int64(size)
+			}
 		}
 	}
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -52,6 +52,7 @@ func ReceiveEvent(ctx context.Context, msg *pubsub.Message) error {
 	}
 	log.Printf("Subscribed message(Command): %v", payload.Command)
 
+	log.Printf("Project ID: %v", e.ProjectID)
 	opts := scheduler.NewOptions(e.ProjectID, e.SlackToken, e.SlackChannel, e.SlackNotify)
 
 	switch payload.Command {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -121,6 +121,7 @@ func Restart(ctx context.Context, op *Options) error {
 		log.Printf("Some error occurred in starting instances group: %v\n", err)
 	}
 	result = append(result, rpt)
+	rpt.Show()
 
 	rpt, err = operator.ComputeEngine(ctx, projectID).Filter(Label, true).Start()
 	if err != nil {
@@ -128,6 +129,7 @@ func Restart(ctx context.Context, op *Options) error {
 		log.Printf("Some error occurred in starting compute engine: %v\n", err)
 	}
 	result = append(result, rpt)
+	rpt.Show()
 
 	rpt, err = operator.SQL(ctx, projectID).Filter(Label, true).Start()
 	if err != nil {
@@ -135,6 +137,7 @@ func Restart(ctx context.Context, op *Options) error {
 		log.Printf("Some error occurred in starting SQL: %v\n", err)
 	}
 	result = append(result, rpt)
+	rpt.Show()
 
 	if !op.SlackEnable {
 		log.Printf("done.")

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -48,7 +48,6 @@ func NewOptions(projectID, slackToken, slackChannel string, slackEnable bool) *O
 
 func Shutdown(ctx context.Context, op *Options) error {
 	projectID := op.Project
-	log.Printf("Project ID: %v", projectID)
 
 	var errorLog error
 	var result []*model.Report
@@ -112,7 +111,6 @@ func Shutdown(ctx context.Context, op *Options) error {
 
 func Restart(ctx context.Context, op *Options) error {
 	projectID := op.Project
-	log.Printf("Project ID: %v", projectID)
 
 	var errorLog error
 	var result []*model.Report
@@ -124,14 +122,14 @@ func Restart(ctx context.Context, op *Options) error {
 	}
 	result = append(result, rpt)
 
-	rpt, err = operator.ComputeEngine(ctx, projectID).Filter(Label, true).Stop()
+	rpt, err = operator.ComputeEngine(ctx, projectID).Filter(Label, true).Start()
 	if err != nil {
 		errorLog = multierror.Append(errorLog, err)
 		log.Printf("Some error occurred in starting compute engine: %v\n", err)
 	}
 	result = append(result, rpt)
 
-	rpt, err = operator.SQL(ctx, projectID).Filter(Label, true).Stop()
+	rpt, err = operator.SQL(ctx, projectID).Filter(Label, true).Start()
 	if err != nil {
 		errorLog = multierror.Append(errorLog, err)
 		log.Printf("Some error occurred in starting SQL: %v\n", err)


### PR DESCRIPTION
# Changes proposed in this pull request
* For issue #9

# What did you Implement: 
* add cli interface and restart function in scheduler.go

# How Has This Been Tested? 

```bash
##  Restart（duplicated call）
## 
>scheduler restart --project dev-dx
2019/08/22 16:30:17 Project ID: dev-dx
2019/08/22 16:30:20 [InstanceGroup]
2019/08/22 16:30:20 └- Shutdown Resource: 0
2019/08/22 16:30:20 └- Already Shutdown Resource: 2
2019/08/22 16:30:20     └-- gke-standard-cluster-1-default-pool-f789c8df-grp
2019/08/22 16:30:20     └-- gke-standard-cluster-1-pool-1-c0f50c60-grp
2019/08/22 16:30:21 [ComputeEngine]
2019/08/22 16:30:21 └- Shutdown Resource: 0
2019/08/22 16:30:21 └- Already Shutdown Resource: 1
2019/08/22 16:30:21     └-- shutdown-test
2019/08/22 16:30:22 [SQL]
2019/08/22 16:30:22 └- Shutdown Resource: 0
2019/08/22 16:30:22 └- Already Shutdown Resource: 1
2019/08/22 16:30:22     └-- shutdown-test
2019/08/22 16:30:22 done.

## Stop
## 
>scheduler stop --project dev-dx
2019/08/22 16:31:38 Project ID: dev-dx
2019/08/22 16:31:40 Cluster [Name]standard-cluster-1 [Status]RUNNING
2019/08/22 16:31:45 [InstanceGroup]
2019/08/22 16:31:45 └- Shutdown Resource: 2
2019/08/22 16:31:45   └-- gke-standard-cluster-1-default-pool-f789c8df-grp
2019/08/22 16:31:45   └-- gke-standard-cluster-1-pool-1-c0f50c60-grp
2019/08/22 16:31:45 └- Already Shutdown Resource: 0
2019/08/22 16:31:46 [ComputeEngine]
2019/08/22 16:31:46 └- Shutdown Resource: 1
2019/08/22 16:31:46   └-- shutdown-test
2019/08/22 16:31:46 └- Already Shutdown Resource: 0
2019/08/22 16:31:47 [SQL]
2019/08/22 16:31:47 └- Shutdown Resource: 1
2019/08/22 16:31:47   └-- shutdown-test
2019/08/22 16:31:47 └- Already Shutdown Resource: 0
2019/08/22 16:31:47 done.

## Restart（Stop Resource）
>scheduler restart --project dev-dx
2019/08/22 16:37:22 Project ID: dev-dx
2019/08/22 16:37:28 [InstanceGroup]
2019/08/22 16:37:28 └- Shutdown Resource: 2
2019/08/22 16:37:28   └-- gke-standard-cluster-1-default-pool-f789c8df-grp
2019/08/22 16:37:28   └-- gke-standard-cluster-1-pool-1-c0f50c60-grp
2019/08/22 16:37:28 └- Already Shutdown Resource: 0
2019/08/22 16:37:30 [ComputeEngine]
2019/08/22 16:37:30 └- Shutdown Resource: 1
2019/08/22 16:37:30   └-- shutdown-test
2019/08/22 16:37:30 └- Already Shutdown Resource: 0
2019/08/22 16:37:32 [SQL]
2019/08/22 16:37:32 └- Shutdown Resource: 1
2019/08/22 16:37:32   └-- shutdown-test
2019/08/22 16:37:32 └- Already Shutdown Resource: 0
2019/08/22 16:37:32 done.


```

# Reference
> https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/
