### PR TITLE
#37 change restart resource order

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -111,11 +111,12 @@ func Restart(ctx context.Context, op *Options) error {
 	var errorLog error
 	var result []*model.Report
 
-	rpt, err := operator.InstanceGroup(ctx, projectID).Filter(Label, true).Recovery()
+	rpt, err := operator.SQL(ctx, projectID).Filter(Label, true).Start()
 	if err != nil {
 		errorLog = multierror.Append(errorLog, err)
-		log.Printf("Some error occurred in starting instances group: %v\n", err)
+		log.Printf("Some error occurred in starting SQL: %v\n", err)
 	}
+
 	result = append(result, rpt)
 	log.Println(strings.Join(rpt.Show(), "\n"))
 
@@ -127,10 +128,10 @@ func Restart(ctx context.Context, op *Options) error {
 	result = append(result, rpt)
 	log.Println(strings.Join(rpt.Show(), "\n"))
 
-	rpt, err = operator.SQL(ctx, projectID).Filter(Label, true).Start()
+	rpt, err = operator.InstanceGroup(ctx, projectID).Filter(Label, true).Recovery()
 	if err != nil {
 		errorLog = multierror.Append(errorLog, err)
-		log.Printf("Some error occurred in starting SQL: %v\n", err)
+		log.Printf("Some error occurred in starting instances group: %v\n", err)
 	}
 	result = append(result, rpt)
 	log.Println(strings.Join(rpt.Show(), "\n"))


### PR DESCRIPTION
# Changes proposed in this pull request
* For issue #37

# What did you Implement: 
* Change order simply.

# How Has This Been Tested? 

```console
scheduler --project xxx --slackNotifyEnable true --slackChannel=xxxx --slackToken xoxp-xxx  stop
2019/08/28 11:27:51 Project ID: xxx
2019/08/28 11:27:53 Cluster [Name]standard-cluster-1 [Status]RUNNING
2019/08/28 11:27:56 .InstanceGroup
  └- Done: 0
  └- AlreadyDone: 2
    └-- gke-standard-cluster-1-default-pool-f789c8df-grp
    └-- gke-standard-cluster-1-pool-1-c0f50c60-grp
  └- Skip: 2
    └-- gke-standard-cluster-1-default-pool-f789c8df-grp
    └-- gke-standard-cluster-1-pool-1-c0f50c60-grp
2019/08/28 11:27:56 .ComputeEngine
  └- Done: 0
  └- AlreadyDone: 1
    └-- shutdown-test
  └- Skip: 1
    └-- shutdown-test
2019/08/28 11:27:57 .SQL
  └- Done: 0
  └- AlreadyDone: 1
    └-- shutdown-test
  └- Skip: 1
    └-- shutdown-test
2019/08/28 11:27:57 done.


>scheduler --project xxx --slackNotifyEnable true --slackChannel=xxx--slackToken xoxp-xxx  restart
2019/08/28 11:29:57 Project ID: xxx
2019/08/28 11:29:59 .SQL
  └- Done: 1
    └-- shutdown-test
  └- AlreadyDone: 0
  └- Skip: 0
2019/08/28 11:30:01 .ComputeEngine
  └- Done: 1
    └-- shutdown-test
  └- AlreadyDone: 0
  └- Skip: 0
2019/08/28 11:30:06 .InstanceGroup
  └- Done: 2
    └-- gke-standard-cluster-1-default-pool-f789c8df-grp
    └-- gke-standard-cluster-1-pool-1-c0f50c60-grp
  └- AlreadyDone: 0
  └- Skip: 0
2019/08/28 11:30:06 done.
```
