### PR TITLE
Disable set label

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ gcloud beta sql instances patch <insntance-name> \
 gcloud container clusters update <cluster-name> \
   --project <project-id> \
   --zone <cluster-master-node-zone> \
-  --update-labels state-scheduler=true
+  --update-labels state-scheduler=true,restore-size-<node-pool-name>=<node-size>
 ```
 
 

--- a/operator/gke.go
+++ b/operator/gke.go
@@ -213,6 +213,7 @@ func (r *GKENodePoolCall) getGKEInstanceGroup() (set.Set, error) {
 	return res, nil
 }
 
+/*
 func SetLabelNodePoolSize(ctx context.Context, projectID string, targetLabel string) error {
 	s, err := container.NewService(ctx)
 	if err != nil {
@@ -248,6 +249,7 @@ func SetLabelNodePoolSize(ctx context.Context, projectID string, targetLabel str
 
 	return nil
 }
+*/
 
 // GetOriginalNodePoolSize returns map that key=instanceGroupName and value=originalSize
 func GetOriginalNodePoolSize(ctx context.Context, projectID, targetLabel, labelValue string) (map[string]int64, error) {

--- a/operator/gke.go
+++ b/operator/gke.go
@@ -213,43 +213,8 @@ func (r *GKENodePoolCall) getGKEInstanceGroup() (set.Set, error) {
 	return res, nil
 }
 
-/*
-func SetLabelNodePoolSize(ctx context.Context, projectID string, targetLabel string) error {
-	s, err := container.NewService(ctx)
-	if err != nil {
-		return err
-	}
 
-	// get all clusters list
-	clusters, err := container.NewProjectsLocationsClustersService(s).List("projects/" + projectID + "/locations/-").Do()
-	if err != nil {
-		return err
-	}
 
-	// filtering with target label
-	for _, cluster := range filter(clusters.Clusters, targetLabel, "true") {
-		labels := cluster.ResourceLabels
-		for _, nodePool := range cluster.NodePools {
-			nodeSizeLabel := "restore-size-" + nodePool.Name
-			labels[nodeSizeLabel] = strconv.FormatInt(nodePool.InitialNodeCount, 10)
-		}
-
-		parseRegion := strings.Split(cluster.Location, "/")
-		region := parseRegion[len(parseRegion)-1]
-		name := "projects/" + projectID + "/locations/" + region + "/clusters/" + cluster.Name
-		req := &container.SetLabelsRequest{
-			ResourceLabels: labels,
-		}
-
-		_, err := container.NewProjectsLocationsClustersService(s).SetResourceLabels(name, req).Do()
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-*/
 
 // GetOriginalNodePoolSize returns map that key=instanceGroupName and value=originalSize
 func GetOriginalNodePoolSize(ctx context.Context, projectID, targetLabel, labelValue string) (map[string]int64, error) {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -52,12 +52,6 @@ func Shutdown(ctx context.Context, op *Options) error {
 	var errorLog error
 	var result []*model.Report
 
-	/*
-	if err := operator.SetLabelNodePoolSize(ctx, projectID, Label); err != nil {
-		errorLog = multierror.Append(errorLog, err)
-		log.Printf("Error in setting labels on GKE cluster: %v", err)
-	}
-	*/
 
 	rpt, err := operator.GKENodePool(ctx, projectID).Filter(Label, "true").Resize(0)
 	if err != nil {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -52,10 +52,12 @@ func Shutdown(ctx context.Context, op *Options) error {
 	var errorLog error
 	var result []*model.Report
 
+	/*
 	if err := operator.SetLabelNodePoolSize(ctx, projectID, Label); err != nil {
 		errorLog = multierror.Append(errorLog, err)
 		log.Printf("Error in setting labels on GKE cluster: %v", err)
 	}
+	*/
 
 	rpt, err := operator.GKENodePool(ctx, projectID).Filter(Label, "true").Resize(0)
 	if err != nil {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -53,6 +53,10 @@ func Shutdown(ctx context.Context, op *Options) error {
 	var result []*model.Report
 
 
+	if err := operator.SetLableIfNoLabel(ctx, projectID, Label); err != nil {
+		errorLog = multierror.Append(errorLog, err)
+		log.Printf("Error in setting labels on GKE cluster: %v", err)
+	}
 	rpt, err := operator.GKENodePool(ctx, projectID).Filter(Label, "true").Resize(0)
 	if err != nil {
 		errorLog = multierror.Append(errorLog, err)


### PR DESCRIPTION
# Changes proposed in this pull request
* not to overwrite "restore-size-\<node-pool-name\>" label
* if no "restore-size-\<node-pool-name\>" label, 
set "restore-size-\<node-pool-name\>" =\<current-node-size\>

# What did you Implement: 
* delete SetLabelNodePoolSize in "operator/gke.go"
* not to call SetLabelNodePoolSize in "scheduler/scheduler.go"
* create GetCurrentNodeCount & SetLableIfNoLabel in "operator/gke.go"
* call SetLableIfNoLabel in "scheduler/scheduler.go"
* change "Example: create target resources" about this in "README.md"

# How Has This Been Tested? 
* xxx
